### PR TITLE
Fix packet reader app

### DIFF
--- a/packet-reader/Makefile
+++ b/packet-reader/Makefile
@@ -1,56 +1,15 @@
-# SPDX-License-Identifier: BSD-3-Clause
-# Copyright(c) 2010-2014 Intel Corporation
+LDFLAGS = -march=native -O2
+INCLUDE = -I ${RTE_SDK}/build/include -L ${RTE_SDK}/build/lib
+LIBS = -Wl,--whole-archive \
+		-lrte_pmd_e1000 -lrte_ethdev -lrte_eal \
+		-lrte_mbuf -lrte_mempool -lrte_mempool_ring \
+		-lrte_ring -lrte_hash -lrt -lm -ldl \
+		-lnuma -lpthread -lrte_pci -lrte_bus_pci \
+		-lrte_kvargs -lrte_cmdline -Wl,--no-whole-archive \
 
-# binary name
-APP = capture
-
-# all source are stored in SRCS-y
-SRCS-y := main.c
-
-# Build using pkg-config variables if possible
-$(shell pkg-config --exists libdpdk)
-ifeq ($(.SHELLSTATUS),0)
-
-all: shared
-.PHONY: shared static
-shared: build/$(APP)-shared
-        ln -sf $(APP)-shared build/$(APP)
-static: build/$(APP)-static
-        ln -sf $(APP)-static build/$(APP)
-
-PC_FILE := $(shell pkg-config --path libdpdk)
-CFLAGS += -O3 $(shell pkg-config --cflags libdpdk)
-LDFLAGS_SHARED = $(shell pkg-config --libs libdpdk)
-LDFLAGS_STATIC = -Wl,-Bstatic $(shell pkg-config --static --libs libdpdk)
-
-build/$(APP)-shared: $(SRCS-y) Makefile $(PC_FILE) | build
-        $(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_SHARED)
-
-build/$(APP)-static: $(SRCS-y) Makefile $(PC_FILE) | build
-        $(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_STATIC)
-
-build:
-        @mkdir -p $@
+capture: main.c
+		gcc $^ -o $@ $(LDFLAGS) $(INCLUDE) $(LIBS)
 
 .PHONY: clean
 clean:
-        rm -f build/$(APP) build/$(APP)-static build/$(APP)-shared
-        rmdir --ignore-fail-on-non-empty build
-
-else
-
-ifeq ($(RTE_SDK),)
-$(error "Please define RTE_SDK environment variable")
-endif
-
-# Default target, detect a build directory, by looking for a path with a .config
-RTE_TARGET ?= $(notdir $(abspath $(dir $(firstword $(wildcard $(RTE_SDK)/*/.config)))))
-
-include $(RTE_SDK)/mk/rte.vars.mk
-
-CFLAGS += -O3
-CFLAGS += $(WERROR_FLAGS)
-
-include $(RTE_SDK)/mk/rte.extapp.mk
-
-endif
+		rm -f capture

--- a/packet-reader/Makefile
+++ b/packet-reader/Makefile
@@ -1,15 +1,62 @@
-LDFLAGS = -march=native -O2
-INCLUDE = -I ${RTE_SDK}/build/include -L ${RTE_SDK}/build/lib
-LIBS = -Wl,--whole-archive \
-		-lrte_pmd_e1000 -lrte_ethdev -lrte_eal \
-		-lrte_mbuf -lrte_mempool -lrte_mempool_ring \
-		-lrte_ring -lrte_hash -lrt -lm -ldl \
-		-lnuma -lpthread -lrte_pci -lrte_bus_pci \
-		-lrte_kvargs -lrte_cmdline -Wl,--no-whole-archive \
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2010-2014 Intel Corporation
 
-capture: main.c
-		gcc $^ -o $@ $(LDFLAGS) $(INCLUDE) $(LIBS)
+# binary name
+APP = capture
+
+# all source are stored in SRCS-y
+SRCS-y := main.c
+
+# Build using pkg-config variables if possible
+$(shell pkg-config --exists libdpdk)
+ifeq ($(.SHELLSTATUS),0)
+
+all: shared
+.PHONY: shared static
+shared: build/$(APP)-shared
+	ln -sf $(APP)-shared build/$(APP)
+static: build/$(APP)-static
+	ln -sf $(APP)-static build/$(APP)
+
+PC_FILE := $(shell pkg-config --path libdpdk)
+CFLAGS += -O3 $(shell pkg-config --cflags libdpdk)
+LDFLAGS_SHARED = $(shell pkg-config --libs libdpdk)
+LDFLAGS_STATIC = -Wl,-Bstatic $(shell pkg-config --static --libs libdpdk)
+
+build/$(APP)-shared: $(SRCS-y) Makefile $(PC_FILE) | build
+	$(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_SHARED)
+
+build/$(APP)-static: $(SRCS-y) Makefile $(PC_FILE) | build
+	$(CC) $(CFLAGS) $(SRCS-y) -o $@ $(LDFLAGS) $(LDFLAGS_STATIC)
+
+build:
+	@mkdir -p $@
 
 .PHONY: clean
 clean:
-		rm -f capture
+	rm -f build/$(APP) build/$(APP)-static build/$(APP)-shared
+	rmdir --ignore-fail-on-non-empty build
+
+else # Build using legacy build system
+
+ifeq ($(RTE_SDK),)
+$(error "Please define RTE_SDK environment variable")
+endif
+
+# Default target, can be overridden by command line or environment
+RTE_TARGET ?= x86_64-native-linuxapp-gcc
+
+include $(RTE_SDK)/mk/rte.vars.mk
+
+CFLAGS += $(WERROR_FLAGS)
+
+# workaround for a gcc bug with noreturn attribute
+# http://gcc.gnu.org/bugzilla/show_bug.cgi?id=12603
+ifeq ($(CONFIG_RTE_TOOLCHAIN_GCC),y)
+CFLAGS_main.o += -Wno-return-type
+endif
+
+EXTRA_CFLAGS += -O3 -g -Wfatal-errors
+
+include $(RTE_SDK)/mk/rte.extapp.mk
+endif

--- a/packet-reader/main.c
+++ b/packet-reader/main.c
@@ -23,7 +23,7 @@ static const struct rte_eth_conf port_conf_default = {
 /*
  * Validate whether the current user has root privileges.
  */
-bool is_user_root()
+static bool is_user_root(void)
 {
 	if (getuid())
 	{
@@ -37,16 +37,16 @@ bool is_user_root()
 /*
  * Signal handler that stops the packet capture loop.
  */
-void stop_polling()
+static void stop_polling(int ret)
 {
-	printf("\rInterrupt received, stopping live capture\n");
+	printf("\rInterrupt received, stopping live capture  (return code: %d\n", ret);
 	continue_polling = false;
 }
 
 /* 
  * Initialize the receive descriptors for the given DPDK port.
  */
-int port_init(uint8_t port, struct rte_mempool *mbuf_pool)
+static int port_init(uint8_t port, struct rte_mempool *mbuf_pool)
 {
 	int retval;
 	uint16_t nb_txd = 0;
@@ -81,30 +81,36 @@ int port_init(uint8_t port, struct rte_mempool *mbuf_pool)
 /*
  * Function to initialize the DPDK framework.
  */
-struct rte_mempool *initialize_dpdk(int argc, char **argv, uint8_t port)
+static struct rte_mempool *initialize_dpdk(int argc, char **argv, uint8_t port)
 {
 	// Initialize abstraction layer
 	int ret = rte_eal_init(argc, argv);
-
 	if (ret < 0)
+	{
 		rte_exit(EXIT_FAILURE, "Error with EAL initialization\n");
+	}
 
 	// Enumerate available ports
-	uint nb_ports = rte_eth_dev_count_avail();
-
+	unsigned nb_ports = rte_eth_dev_count_avail();
 	if (nb_ports == 0)
-		rte_exit(EXIT_FAILURE, "No assigned network interfaces found\n  Run \"sudo ./bind-nic-to-dpdk.sh\" to assign the host-only adapter to DPDK\n");
+	{
+		rte_exit(EXIT_FAILURE, "ERR: No assigned network interfaces found\n  Run \"sudo ./bind-nic-to-dpdk.sh\" to assign the host-only adapter to DPDK\n");
+	}
 
 	// Allocate memory pool for packets
 	struct rte_mempool *mbuf_pool;
 	mbuf_pool = rte_pktmbuf_pool_create("MBUF_POOL", NUM_MBUFS * nb_ports, MBUF_CACHE_SIZE, 0, RTE_MBUF_DEFAULT_BUF_SIZE, rte_socket_id());
 
 	if (mbuf_pool == NULL)
+	{
 		rte_exit(EXIT_FAILURE, "Cannot create mbuf pool\n");
+	}
 
 	// Initialize NIC receive port
 	if (port_init(port, mbuf_pool) != 0)
+	{
 		rte_exit(EXIT_FAILURE, "Cannot init port %u\n", port);
+	}
 
 	return mbuf_pool;
 }
@@ -112,7 +118,7 @@ struct rte_mempool *initialize_dpdk(int argc, char **argv, uint8_t port)
 /*
  * Display some basic information about the packet, like MAC and IP addresses.
  */
-void process_packet(struct rte_mbuf *mbuf)
+static void process_packet(struct rte_mbuf *mbuf)
 {
 	u_char *p = rte_pktmbuf_mtod(mbuf, u_char *);
 	uint16_t length = rte_pktmbuf_data_len(mbuf);
@@ -164,6 +170,10 @@ int main(int argc, char **argv)
 	// Initialize DPDK
 	uint8_t port = 0;
 	struct rte_mempool *mbuf_pool = initialize_dpdk(argc, argv, port);
+	if (mbuf_pool == NULL)
+	{
+		exit(1);
+	}
 	struct rte_mbuf *bufs[BURST_SIZE];
 
 	// Main packet capture loop

--- a/packet-reader/main.c
+++ b/packet-reader/main.c
@@ -15,7 +15,9 @@
 
 bool continue_polling = true;
 static const struct rte_eth_conf port_conf_default = {
-	.rxmode = { .max_rx_pkt_len = ETHER_MAX_LEN, },
+	.rxmode = {
+		.max_rx_pkt_len = ETHER_MAX_LEN,
+	},
 };
 
 /*
@@ -51,7 +53,7 @@ int port_init(uint8_t port, struct rte_mempool *mbuf_pool)
 	uint16_t nb_rxd = RX_RING_SIZE;
 	struct rte_eth_conf port_conf = port_conf_default;
 
-	if (port >= rte_eth_dev_count())
+	if (port >= rte_eth_dev_count_avail())
 		return -1;
 
 	retval = rte_eth_dev_configure(port, 1, 0, &port_conf);
@@ -68,7 +70,7 @@ int port_init(uint8_t port, struct rte_mempool *mbuf_pool)
 	if (retval < 0)
 		return retval;
 
-	retval  = rte_eth_dev_start(port);
+	retval = rte_eth_dev_start(port);
 	if (retval < 0)
 		return retval;
 
@@ -88,7 +90,7 @@ struct rte_mempool *initialize_dpdk(int argc, char **argv, uint8_t port)
 		rte_exit(EXIT_FAILURE, "Error with EAL initialization\n");
 
 	// Enumerate available ports
-	uint nb_ports = rte_eth_dev_count();
+	uint nb_ports = rte_eth_dev_count_avail();
 
 	if (nb_ports == 0)
 		rte_exit(EXIT_FAILURE, "No assigned network interfaces found\n  Run \"sudo ./bind-nic-to-dpdk.sh\" to assign the host-only adapter to DPDK\n");
@@ -112,7 +114,7 @@ struct rte_mempool *initialize_dpdk(int argc, char **argv, uint8_t port)
  */
 void process_packet(struct rte_mbuf *mbuf)
 {
-	u_char *p = rte_pktmbuf_mtod(mbuf, u_char*);
+	u_char *p = rte_pktmbuf_mtod(mbuf, u_char *);
 	uint16_t length = rte_pktmbuf_data_len(mbuf);
 	printf("---------------------------\n");
 
@@ -131,19 +133,19 @@ void process_packet(struct rte_mbuf *mbuf)
 	printf("IP dst = %u.%u.%u.%u\n", p[30], p[31], p[32], p[33]);
 
 	// Get IP payload protocol
-	switch(p[23])
+	switch (p[23])
 	{
-		case 0x01:
-			printf("ICMP payload\n");
-			break;
-		case 0x06:
-			printf("TCP payload\n");
-			break;
-		case 0x11:
-			printf("UDP payload\n");
-			break;
-		default:
-			printf("Unknown payload\n");
+	case 0x01:
+		printf("ICMP payload\n");
+		break;
+	case 0x06:
+		printf("TCP payload\n");
+		break;
+	case 0x11:
+		printf("UDP payload\n");
+		break;
+	default:
+		printf("Unknown payload\n");
 	}
 }
 


### PR DESCRIPTION
Hi @lenigoor 

I noticed that in my previous PR, there was some usage of deprecated functions (i.e. `rte_eth_dev_count()`) which I replaced.

Secondly, your `Makefile` seems to be using spaces. Replaced them with tabs.

Are you interested in adding the capability to launch using the `libvirt` provider?